### PR TITLE
Add msgpack module installation requirement

### DIFF
--- a/install.html
+++ b/install.html
@@ -100,6 +100,11 @@ also need <em>Xcode</em>.</p>
 </pre></div>
 </div>
 </li>
+<li><p class="first">
+        Install <a class="reference external" href="https://pypi.python.org/pypi/msgpack-python">msgpack python module</a> using:
+    <div class="highlight"><pre>pip install msgpack-python</pre></div>
+    </p>
+</li>
 <li><p class="first">Download the madIS archive (.zip) from:</p>
 <p><a class="reference external" href="http://code.google.com/p/madis/downloads/list">http://code.google.com/p/madis/downloads/list</a></p>
 </li>


### PR DESCRIPTION
**Problem** 
`msgpack` module was needed to run a `coutput` UDF, like this: `coutput './output' mode:sdc select * from file('a.csv');`. 

**Changes**
Added msgpack module requirement in installation directions.
