### PR TITLE
Added URLError exception handle at urlrequest

### DIFF
--- a/src/functions/row/util.py
+++ b/src/functions/row/util.py
@@ -106,7 +106,7 @@ def urlrequest(*args):
 
         return unicode(hreq.read(), 'utf-8', errors = 'replace')
 
-    except urllib2.HTTPError,e:
+    except (urllib2.HTTPError, urllib2.URLError),e:
         if args[0] == None:
             return None
         else:


### PR DESCRIPTION
Problem
at urlrequest: some urls with TLSv23 issue
Traceback is:
  File "/usr/lib/python2.7/urllib2.py", line 1184, in do_open
    raise URLError(err)
URLError: <urlopen error [Errno 8] _ssl.c:510: EOF occurred in violation of protocol>

Changes
Added URLError exception handle at urlrequest
